### PR TITLE
Fix sound delay bug

### DIFF
--- a/NoodleExtensions/HarmonyPatches/CustomLevelLoader.cs
+++ b/NoodleExtensions/HarmonyPatches/CustomLevelLoader.cs
@@ -56,18 +56,23 @@
                             }
 
                             dynamic dynData = customData.customData;
-                            float noteJumpMovementSpeed = (float?)Trees.at(dynData, NOTEJUMPSPEED) ?? difficultyBeatmap.noteJumpMovementSpeed;
-                            float noteJumpStartBeatOffset = (float?)Trees.at(dynData, NOTESPAWNOFFSET) ?? difficultyBeatmap.noteJumpStartBeatOffset;
+                            float? noteJumpMovementSpeed = (float?)Trees.at(dynData, NOTEJUMPSPEED);
+                            float? noteJumpStartBeatOffset = (float?)Trees.at(dynData, NOTESPAWNOFFSET);
+
+                            if (!noteJumpMovementSpeed.HasValue && !noteJumpStartBeatOffset.HasValue)
+                            {
+                                return;
+                            }
 
                             // how do i not repeat this in a reasonable way
                             float num = 60f / (float)Trees.at(dynData, "bpm");
                             float num2 = startHalfJumpDurationInBeats;
-                            while (noteJumpMovementSpeed * num * num2 > maxHalfJumpDistance)
+                            while ((noteJumpMovementSpeed ?? difficultyBeatmap.noteJumpMovementSpeed) * num * num2 > maxHalfJumpDistance)
                             {
                                 num2 /= 2f;
                             }
 
-                            num2 += noteJumpStartBeatOffset;
+                            num2 += noteJumpStartBeatOffset ?? difficultyBeatmap.noteJumpStartBeatOffset;
                             if (num2 < 1f)
                             {
                                 num2 = 1f;

--- a/NoodleExtensions/HarmonyPatches/CustomLevelLoader.cs
+++ b/NoodleExtensions/HarmonyPatches/CustomLevelLoader.cs
@@ -61,7 +61,7 @@
 
                             if (!noteJumpMovementSpeed.HasValue && !noteJumpStartBeatOffset.HasValue)
                             {
-                                return;
+                                continue;
                             }
 
                             // how do i not repeat this in a reasonable way

--- a/NoodleExtensions/NoodleExtensions.csproj
+++ b/NoodleExtensions/NoodleExtensions.csproj
@@ -35,23 +35,25 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="0Harmony">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Libs\0Harmony.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Colors">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Colors.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Colors.dll</HintPath>
     </Reference>
     <Reference Include="CustomJSONData, Version=0.0.4.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins\CustomJSONData.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Plugins\CustomJSONData.dll</HintPath>
     </Reference>
-    <Reference Include="IPA.Loader">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\IPA\Data\Managed\IPA.Loader.dll</HintPath>
+    <Reference Include="IPA.Loader, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <Private>False</Private>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Main">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Main.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
     </Reference>
     <Reference Include="SongCore">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins\SongCore.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Plugins\SongCore.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -61,14 +63,14 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.dll</HintPath>
     </Reference>
     <Reference Include="UnityEngine.CoreModule">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
     <Reference Include="Zenject, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Zenject.dll</HintPath>
+      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -135,6 +137,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>copy /Y "$(TargetDir)$(TargetName).dll" "C:\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins\$(TargetName).dll"</PostBuildEvent>
+    <PostBuildEvent>copy /Y "$(TargetDir)$(TargetName).dll" "$(BeatSaberDir)\Plugins\$(TargetName).dll"</PostBuildEvent>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
This PR fixes the sound delay bug present on maps such as Rain, and earlier versions of At Doom's Gate, by only overriding the `aheadTime` property of notes/obstacles if they explicitly define them in `_customData`, rather than applying that to every single note and obstacle.

This PR also includes #14 in it, so that I could create, build, and test these changes on my local Beat Saber install.

And, I'll be blunt right here: I think StyleCopAnalyzers is seriously impeding our ability to read and understand your code, as well as yourself to write code. I see that you have their warnings disabled in a lot of places, that probably means that it's not right for you.