### PR TITLE
Multiplayer fix

### DIFF
--- a/NoodleExtensions/Animation/PlayerTrack.cs
+++ b/NoodleExtensions/Animation/PlayerTrack.cs
@@ -35,7 +35,9 @@
 
         private void Update()
         {
-            bool paused = PauseBool(ref _pauseController);
+            bool paused = false;
+            if (_pauseController != null)
+                paused = PauseBool(ref _pauseController);
 
             Quaternion? rotation = TryGetProperty(_track, ROTATION);
             if (rotation.HasValue)


### PR DESCRIPTION
* Fixed getting `MethodInfo` for `SetArrowTransparency`
  * Created a method that gets the `SetArrowTransparency` `MethodInfo` for the given type
  * Caches the result in a dictionary.
* Added a null check for `_pauseController` in `PlayerTrack`
  * Multiplayer has no pause controller, in the case of it not existing, assume the game isn't paused.