### PR TITLE
Multiplayer fix v2

### DIFF
--- a/NoodleExtensions/Animation/AnimationHelper.cs
+++ b/NoodleExtensions/Animation/AnimationHelper.cs
@@ -57,9 +57,15 @@
             {
                 if (_beatmapObjectSpawnController == null)
                 {
-                    // TODO: find a better way to get the BeatmapObjectManager
                     BeatmapObjectSpawnController spawnController = HarmonyPatches.BeatmapObjectSpawnControllerStart.BeatmapObjectSpawnController;
-                    IBeatmapObjectSpawner beatmapObjectSpawner = _beatmapObjectSpawnAccessor(ref spawnController);
+
+                    IBeatmapObjectSpawner beatmapObjectSpawner = NoodleInstaller.DiContainer.TryResolve<IBeatmapObjectSpawner>();
+                    if (beatmapObjectSpawner == null)
+                    {
+                        NoodleLogger.IPAlogger.Warn($"Could not get IBeatmapObjectSpawner through Zenject.");
+                        beatmapObjectSpawner = _beatmapObjectSpawnAccessor(ref spawnController);
+                    }
+
                     if (beatmapObjectSpawner is BasicBeatmapObjectManager basicBeatmapObjectManager)
                     {
                         _beatmapObjectManager = basicBeatmapObjectManager;

--- a/NoodleExtensions/Directory.Build.targets
+++ b/NoodleExtensions/Directory.Build.targets
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <BuildTargetsVersion>2.0</BuildTargetsVersion>
     <!--Set this to true if you edit this file to prevent automatic updates-->
-    <BuildTargetsModified>false</BuildTargetsModified>
+    <BuildTargetsModified>true</BuildTargetsModified>
     <!--Output assembly path without extension-->
     <OutputAssemblyName>$(OutputPath)$(AssemblyName)</OutputAssemblyName>
     <!--Path to folder to be zipped. Needs to be relative to the project directory to work without changes to the 'BuildForCI' target.-->
@@ -20,16 +20,20 @@
   <!--Runs a build task to get info about the project used by later targets.-->
   <Target Name="GetProjectInfo" AfterTargets="CheckBSMTInstalled" DependsOnTargets="CheckBSMTInstalled" Condition="'$(BSMTTaskAssembly)' != ''">
     <Message Text="Using AssemblyVersion defined in project instead of 'Properties\AssemblyInfo.cs'" Importance="high" Condition="'$(AssemblyVersion)' != ''" />
-    <GetManifestInfo KnownAssemblyVersion="$(AssemblyVersion)" ErrorOnMismatch="$(ErrorOnMismatchedVersions)">
+    <GetAssemblyInfo Condition="'$(AssemblyVersion)' == ''" >
+      <Output TaskParameter="AssemblyVersion" PropertyName="AssemblyVersion" />
+    </GetAssemblyInfo>
+    <GetManifestInfo FailOnError="$(ErrorOnMismatchedVersions)">
       <Output TaskParameter="PluginVersion" PropertyName="PluginVersion" />
       <Output TaskParameter="GameVersion" PropertyName="GameVersion" />
-      <Output TaskParameter="AssemblyVersion" PropertyName="AssemblyVersion" />
+      <Output TaskParameter="BasePluginVersion" PropertyName="BasePluginVersion" />
     </GetManifestInfo>
     <GetCommitInfo ProjectDir="$(ProjectDir)">
       <Output TaskParameter="CommitHash" PropertyName="CommitHash" />
       <Output TaskParameter="Branch" PropertyName="Branch" />
       <Output TaskParameter="Modified" PropertyName="GitModified" />
     </GetCommitInfo>
+    <CompareVersions ErrorOnMismatch="$(ErrorOnMismatchedVersions)" PluginVersion="$(BasePluginVersion)" AssemblyVersion="$(AssemblyVersion)" />
     <PropertyGroup>
       <!--Build name for artifact/zip file-->
       <ArtifactName>$(AssemblyName)</ArtifactName>

--- a/NoodleExtensions/HarmonyPatches/NoteController.cs
+++ b/NoodleExtensions/HarmonyPatches/NoteController.cs
@@ -39,6 +39,11 @@
         private static void Postfix(NoteController __instance, NoteData noteData, NoteMovement ____noteMovement, Vector3 moveStartPos, Vector3 moveEndPos, Vector3 jumpEndPos)
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
         {
+            if (__instance is MultiplayerConnectedPlayerGameNoteController)
+            {
+                return;
+            }
+
             if (noteData is CustomNoteData customData)
             {
                 dynamic dynData = customData.customData;
@@ -208,6 +213,11 @@
         private static void Prefix(NoteController __instance, NoteData ____noteData, NoteMovement ____noteMovement)
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
         {
+            if (__instance is MultiplayerConnectedPlayerGameNoteController)
+            {
+                return;
+            }
+
             if (____noteData is CustomNoteData customData)
             {
                 CustomNoteData = customData;

--- a/NoodleExtensions/HarmonyPatches/NoteFloorMovement.cs
+++ b/NoodleExtensions/HarmonyPatches/NoteFloorMovement.cs
@@ -41,6 +41,17 @@
 
         private static Vector3 DefiniteNoteFloorMovement(Vector3 original, NoteFloorMovement noteFloorMovement)
         {
+            if (NoteControllerUpdate.CustomNoteData == null)
+            {
+                NoodleLogger.IPAlogger.Debug($"NoteControllerUpdate.CustomNoteData is null.");
+                return original;
+            }
+            else if (NoteControllerUpdate.CustomNoteData.customData == null)
+            {
+                NoodleLogger.IPAlogger.Debug($"NoteControllerUpdate.CustomNoteData.customData is null.");
+                return original;
+            }
+
             dynamic dynData = NoteControllerUpdate.CustomNoteData.customData;
             dynamic animationObject = Trees.at(dynData, "_animation");
             Track track = Trees.at(dynData, "track");

--- a/NoodleExtensions/HarmonyPatches/ObstacleController.cs
+++ b/NoodleExtensions/HarmonyPatches/ObstacleController.cs
@@ -88,6 +88,12 @@
         private static void Postfix(ObstacleController __instance, Quaternion ____worldRotation, ObstacleData obstacleData, Vector3 ____startPos, Vector3 ____midPos, Vector3 ____endPos, ref Bounds ____bounds)
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
         {
+            if (__instance is MultiplayerConnectedPlayerObstacleController)
+            {
+                GameObject.Destroy(__instance);
+                return;
+            }
+
             if (obstacleData is CustomObstacleData customData)
             {
                 dynamic dynData = customData.customData;
@@ -275,6 +281,11 @@
             ref Bounds ____bounds)
 #pragma warning restore SA1313 // Parameter names should begin with lower-case letter
         {
+            if (__instance is MultiplayerConnectedPlayerObstacleController)
+            {
+                return;
+            }
+
             if (____obstacleData is CustomObstacleData customData)
             {
                 dynamic dynData = customData.customData;

--- a/NoodleExtensions/NoodleExtensions.csproj
+++ b/NoodleExtensions/NoodleExtensions.csproj
@@ -65,6 +65,11 @@
       <Private>False</Private>
       <SpecificVersion>False</SpecificVersion>
     </Reference>
+    <Reference Include="SiraUtil">
+      <HintPath>$(BeatSaberDir)\Plugins\SiraUtil.dll</HintPath>
+      <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
+    </Reference>
     <Reference Include="SongCore, Version=3.0.2.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>$(BeatSaberDir)\Plugins\SongCore.dll</HintPath>
@@ -147,6 +152,7 @@
     <Compile Include="HarmonyPatches\SpawnRotationProcessor.cs" />
     <Compile Include="HarmonyPatches\ObstacleController.cs" />
     <Compile Include="HarmonyPatches\SceneTransition\StandardLevelScenesTransitionSetupDataSO.cs" />
+    <Compile Include="NoodleInstaller.cs" />
     <Compile Include="NoodlePatch.cs" />
     <Compile Include="NullableExtensions.cs" />
     <Compile Include="Plugin.cs" />
@@ -160,18 +166,18 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="NoodleExtensions.ruleset" />
-    <None Include="packages.config" />
     <None Include="Directory.Build.props" Condition="Exists('Directory.Build.props')" />
     <None Include="Directory.Build.targets" Condition="Exists('Directory.Build.targets')" />
     <None Include="NoodleExtensions.csproj.user" Condition="Exists('NoodleExtensions.csproj.user')" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.CodeFixes.dll" />
-    <Analyzer Include="..\packages\StyleCop.Analyzers.1.1.118\analyzers\dotnet\cs\StyleCop.Analyzers.dll" />
-  </ItemGroup>
-  <ItemGroup>
     <PackageReference Include="BeatSaberModdingTools.Tasks">
       <Version>1.2.3</Version>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers">
+      <Version>1.1.118</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NoodleExtensions/NoodleExtensions.csproj
+++ b/NoodleExtensions/NoodleExtensions.csproj
@@ -172,7 +172,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BeatSaberModdingTools.Tasks">
-      <Version>1.2.3</Version>
+      <Version>1.3.2</Version>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/NoodleExtensions/NoodleInstaller.cs
+++ b/NoodleExtensions/NoodleInstaller.cs
@@ -1,0 +1,14 @@
+﻿namespace NoodleExtensions
+{
+    using Zenject;
+
+    public class NoodleInstaller : Installer
+    {
+        internal static DiContainer DiContainer { get; private set; }
+
+        public override void InstallBindings()
+        {
+            DiContainer = Container;
+        }
+    }
+}

--- a/NoodleExtensions/Plugin.cs
+++ b/NoodleExtensions/Plugin.cs
@@ -3,6 +3,7 @@
     using System.Reflection;
     using HarmonyLib;
     using IPA;
+    using SiraUtil.Zenject;
     using UnityEngine;
     using IPALogger = IPA.Logging.Logger;
 
@@ -41,11 +42,14 @@
         internal static readonly Harmony _harmonyInstanceCore = new Harmony(HARMONYIDCORE);
         internal static readonly Harmony _harmonyInstance = new Harmony(HARMONYID);
 
+        internal static Zenjector Zenjector { get; private set; }
+
         [Init]
-        public void Init(IPALogger pluginLogger)
+        public void Init(IPALogger pluginLogger, Zenjector zenjector)
         {
             NoodleLogger.IPAlogger = pluginLogger;
             NoodleController.InitNoodlePatches();
+            Zenjector = zenjector;
 
             Animation.TrackManager.TrackManagerCreated += Animation.AssignPlayerToTrack.OnTrackManagerCreated;
             Animation.TrackManager.TrackManagerCreated += Animation.AssignTrackParent.OnTrackManagerCreated;
@@ -57,6 +61,7 @@
         {
             SongCore.Collections.RegisterCapability(CAPABILITY);
             _harmonyInstanceCore.PatchAll(Assembly.GetExecutingAssembly());
+            Zenjector.OnGame<NoodleInstaller>(false);
 
             CustomJSONData.CustomBeatmap.CustomBeatmapData.CustomBeatmapDataWasCreated += FakeNoteRecount.OnCustomBeatmapDataCreated;
         }

--- a/NoodleExtensions/manifest.json
+++ b/NoodleExtensions/manifest.json
@@ -8,6 +8,7 @@
   "version": "1.3.5",
   "dependsOn": {
     "SongCore": "^3.0.3",
+    "SiraUtil": "^2.5.1",
     "CustomJSONData": "^1.1.3",
     "BSIPA": "^4.1.4"
   }

--- a/NoodleExtensions/packages.config
+++ b/NoodleExtensions/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="StyleCop.Analyzers" version="1.1.118" targetFramework="net472" developmentDependency="true" />
-</packages>


### PR DESCRIPTION
* Changes should not affect single player at all (except for using Zenject to get the `IBeatmapObjectSpawner` in `AnimationHelper.cs`).
* Tested using `nulctrl by reaxt (ed2a)` and `love love love you i love you (133c5)`
* No spammed errors (single errors from http-status and Chroma at the start).
* Updated `BeatSaberModdingTools.Tasks` and `Directory.Build.targets`.

Known Bugs:
* Notes pause for a moment at their jump destination.
* In `nulctrl` there were some notes and random walls/objects moving or blinking around under the platform or in the distance. Probably objects belonging to other players.